### PR TITLE
feat: 포인트 구현 및 포인트 테스트코드

### DIFF
--- a/src/main/java/com/example/hungrypangproject/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/hungrypangproject/common/exception/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
     //POINT
     POINT_NOT_ENOUGH(HttpStatus.BAD_REQUEST, "포인트가 부족합니다."),
     POINT_EXCEED_LIMIT(HttpStatus.BAD_REQUEST, "포인트는 결제금액의 10% 이하만 사용 가능합니다."),
+    POINT_NOT_HOLDING(HttpStatus.BAD_REQUEST, "적립 대기중인 포인트가 없습니다."),
 
     //MEMBER
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저를 찾을수 없습니다."),

--- a/src/main/java/com/example/hungrypangproject/domain/order/entity/Order.java
+++ b/src/main/java/com/example/hungrypangproject/domain/order/entity/Order.java
@@ -6,9 +6,7 @@ import com.example.hungrypangproject.domain.member.entity.Member;
 import com.example.hungrypangproject.domain.order.exception.OrderException;
 import com.example.hungrypangproject.domain.store.entity.Store;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.UuidGenerator;
 
 import java.math.BigDecimal;
@@ -21,6 +19,8 @@ import java.util.UUID;
 @Entity
 @Table(name = "orders")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder // 포인트 테스트코드용 임시 붙여높음
+@AllArgsConstructor // 포인트 테스트코드용 임시 붙여놓음
 public class Order extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -87,4 +87,10 @@ public class Order extends BaseEntity {
         this.orderStatus = newStatus;
     }
 
+    // 포인트 사용 (총 금액 - 사용 포인트)
+    public BigDecimal getFinalPaymentAmount() {
+        BigDecimal total = (this.totalPrice != null) ? this.totalPrice : BigDecimal.ZERO;
+        BigDecimal used = (this.usedPoint != null) ? this.usedPoint : BigDecimal.ZERO;
+        return total.subtract(used);
+    }
 }

--- a/src/main/java/com/example/hungrypangproject/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/hungrypangproject/domain/order/service/OrderService.java
@@ -91,7 +91,7 @@ public class OrderService {
             Member findMember = memberRepository.findById(userId).orElseThrow(
                     () -> new OrderException(ErrorCode.MEMBER_NOT_FOUND)
             );
-            if (new BigDecimal(findMember.getPoint()).compareTo(request.getUsedPoint()) < 0) {// compareTo 앞 < 뒷 -> -1 반환, 앞 == 뒤 -> 0 반환, 앞 > 뒤 -> 1반환
+            if (new BigDecimal(findMember.getTotalPoint()).compareTo(request.getUsedPoint()) < 0) {// compareTo 앞 < 뒷 -> -1 반환, 앞 == 뒤 -> 0 반환, 앞 > 뒤 -> 1반환
                 throw new OrderException(ErrorCode.POINT_NOT_ENOUGH);
             }
 

--- a/src/main/java/com/example/hungrypangproject/domain/point/entity/Point.java
+++ b/src/main/java/com/example/hungrypangproject/domain/point/entity/Point.java
@@ -1,10 +1,13 @@
 package com.example.hungrypangproject.domain.point.entity;
 
+import com.example.hungrypangproject.common.entity.BaseEntity;
 import com.example.hungrypangproject.domain.member.entity.Member;
+import com.example.hungrypangproject.domain.order.entity.Order;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.aspectj.weaver.ast.Or;
 
 import java.time.LocalDateTime;
 
@@ -12,17 +15,20 @@ import java.time.LocalDateTime;
 @Getter
 @Table(name = "points")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Point {
+public class Point extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
-    private Long orderId;
-
+    // 현재 총 포인트
     @Column(nullable = false)
     private Long currentlyPoint;
 
+    // 적립 포인트
+    @Column(nullable = false)
+    private Long earnPoint;
+
+    // 사용 포인트
     @Column(nullable = false)
     private Long usedPoint;
 
@@ -37,35 +43,39 @@ public class Point {
     private LocalDateTime expireAt;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
+    @JoinColumn(nullable = false, name = "member_id")
     private Member member;
 
-    private LocalDateTime createdAt;
-
-    private LocalDateTime deletedAt;
-
-    private LocalDateTime modifiedAt;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false, name = "order_id")
+    private Order order;
 
     public static Point register(
-            Long orderId,
             Long currentlyPoint,
+            Long earnPoint,
             Long usedPoint,
             PointEnum status,
             Member member,
-            LocalDateTime saveAt,
-            LocalDateTime expiredAt
+            Order order
     ) {
         Point point = new Point();
 
-        point.orderId = orderId;
-        point.currentlyPoint = currentlyPoint;
-        point.usedPoint = usedPoint;
+        point.currentlyPoint = (currentlyPoint != null) ? currentlyPoint:0L;
+        point.earnPoint = (earnPoint != null) ? earnPoint:0L;
+        point.usedPoint = (usedPoint != null) ? usedPoint:0L;
         point.status = status;
         point.member = member;
+        point.order = order;
         point.saveAt = LocalDateTime.now();
         point.expireAt = LocalDateTime.now().plusYears(1);
 
         return point;
     }
 
+    // 배달 완료 시 상태 변경
+    public void activate() {
+        if (this.status == PointEnum.HOLDING) {
+            this.status = PointEnum.SAVE;
+        }
+    }
 }

--- a/src/main/java/com/example/hungrypangproject/domain/point/entity/PointEnum.java
+++ b/src/main/java/com/example/hungrypangproject/domain/point/entity/PointEnum.java
@@ -5,8 +5,8 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 public enum PointEnum {
-    USE("USE","사용가능"),
-    HOLDING("HOLDING","대기중"),
+    USE("USE","사용 가능"),
+    HOLDING("HOLDING","누적 대기"),
     SAVE("SAVE","누적"),
     EXPIRE("EXPIRE","만료");
 

--- a/src/main/java/com/example/hungrypangproject/domain/point/repository/PointRepository.java
+++ b/src/main/java/com/example/hungrypangproject/domain/point/repository/PointRepository.java
@@ -1,7 +1,12 @@
 package com.example.hungrypangproject.domain.point.repository;
 
+import com.example.hungrypangproject.domain.order.entity.Order;
 import com.example.hungrypangproject.domain.point.entity.Point;
+import com.example.hungrypangproject.domain.point.entity.PointEnum;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface PointRepository extends JpaRepository <Point, Long> {
+    Optional<Point> findFirstByOrderAndStatusOrderByCreatedAtDesc(Order order, PointEnum status);
 }

--- a/src/main/java/com/example/hungrypangproject/domain/point/service/PointService.java
+++ b/src/main/java/com/example/hungrypangproject/domain/point/service/PointService.java
@@ -1,0 +1,94 @@
+package com.example.hungrypangproject.domain.point.service;
+
+import com.example.hungrypangproject.common.exception.ErrorCode;
+import com.example.hungrypangproject.common.exception.ServiceException;
+import com.example.hungrypangproject.domain.member.entity.Member;
+import com.example.hungrypangproject.domain.order.entity.Order;
+import com.example.hungrypangproject.domain.point.entity.Point;
+import com.example.hungrypangproject.domain.point.entity.PointEnum;
+import com.example.hungrypangproject.domain.point.repository.PointRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+@Slf4j(topic = "PointService")
+@Service
+@RequiredArgsConstructor
+public class PointService {
+
+    private final PointRepository pointRepository;
+
+    /*
+     * 1. 적립 포인트 계산 : 실 결제 금액의 5% 적립
+     * 2. 포인트 사용 및 로그 생성
+     * 3. 포인트 적립 및 로그 생성
+     * 4. 배달 완료 : 포인트 확정 업데이트
+     */
+
+    @Transactional
+    public Long calculateEarnedPoints (Long totalPrice, Long usedPoints) {
+        long payAmount = totalPrice - usedPoints;
+        return (payAmount * 5) / 100;
+    }
+
+   @Transactional
+    public void usedPoint(Member member, Order order, Long useAmount) {
+        if(useAmount < 100) {
+            throw new ServiceException(ErrorCode.POINT_NOT_ENOUGH);
+        }
+
+        // 결제 금액의 10% 계산
+       BigDecimal totalPrice = order.getTotalPrice();
+        BigDecimal maxLimit = totalPrice.multiply(new BigDecimal("0.1"))
+                .setScale(0, RoundingMode.FLOOR);
+
+        // 사용하려는 포인트가 10% 초과할 때
+        if(BigDecimal.valueOf(useAmount).compareTo(maxLimit) > 0) {
+            throw new ServiceException(ErrorCode.POINT_EXCEED_LIMIT);
+        }
+
+        // 사용가능한 포인트에서 즉시 차감
+        member.minusPoint(useAmount);
+
+        Point useLog = Point.register(
+                member.getTotalPoint(),
+                0L,
+                useAmount,
+                PointEnum.USE,
+                member,
+                order
+        );
+        pointRepository.save(useLog);
+   }
+
+   @Transactional
+    public void reserveEarnPoint(Member member, Order order, Long earnAmount) {
+        // 배달 완료 전 홀딩 상태 포인트 확인
+        Point earnLog = Point.register(
+                member.getTotalPoint(),
+                earnAmount,
+                0L,
+                PointEnum.HOLDING,
+                member,
+                order
+        );
+        pointRepository.save(earnLog);
+   }
+
+   @Transactional
+    public void completePoint(Order order) {
+       // 적립 홀딩 상태 확인
+       Point point = pointRepository.findFirstByOrderAndStatusOrderByCreatedAtDesc(order, PointEnum.HOLDING)
+               .orElseThrow(() -> new ServiceException(ErrorCode.POINT_NOT_HOLDING));
+
+       // 상태 변경 및
+       point.activate();
+       point.getMember().addPoint(point.getEarnPoint());
+
+       log.info("포인트 적립 완료: Member={}, Amount={}",point.getMember(), point.getId(), point.getEarnPoint());
+   }
+}

--- a/src/test/java/com/example/hungrypangproject/domain/point/service/PointServiceTest.java
+++ b/src/test/java/com/example/hungrypangproject/domain/point/service/PointServiceTest.java
@@ -1,0 +1,92 @@
+package com.example.hungrypangproject.domain.point.service;
+
+import com.example.hungrypangproject.common.exception.ErrorCode;
+import com.example.hungrypangproject.common.exception.ServiceException;
+import com.example.hungrypangproject.domain.member.entity.Member;
+import com.example.hungrypangproject.domain.order.entity.Order;
+import com.example.hungrypangproject.domain.point.entity.Point;
+import com.example.hungrypangproject.domain.point.entity.PointEnum;
+import com.example.hungrypangproject.domain.point.repository.PointRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class PointServiceTest {
+
+    @Mock
+    private PointRepository pointRepository;
+
+    @InjectMocks
+    private PointService pointService;
+
+    private Member member;
+    private Order order;
+
+    @BeforeEach
+    void setUp() {
+        member = Member.builder()
+                .memberId(1L)
+                .totalPoint(1000L)
+                .build();
+        order = Order.builder()
+                .id(1L)
+                .orderNum(UUID.fromString(UUID.randomUUID().toString()))
+                .totalPrice(BigDecimal.valueOf(10000))
+                .build();
+    }
+
+    @Test
+    @DisplayName("포인트 적립 : 정확히 5% 계산이 되는지 확인")
+    void calculateEarnedPointsTest() {
+
+        // when
+        Long earnedPoints = pointService.calculateEarnedPoints(10000L,0L);
+
+        // then
+        assertEquals(500L, earnedPoints);
+    }
+
+    @Test
+    @DisplayName("포인트 사용 실페 : 결제 금액의 10% 초과 시 에러")
+    void usePointTest() {
+        // given
+        Long useAmount = 1500L;
+
+        // when & then
+        ServiceException exception = assertThrows(ServiceException.class,
+                () -> {
+            pointService.usedPoint(member, order, useAmount);
+                });
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatus());
+        assertEquals(ErrorCode.POINT_EXCEED_LIMIT.getMessage(), exception.getMessage());}
+
+    @Test
+    @DisplayName("배달 완료 시 포인트 적립 확정")
+    void completePoint_Success() {
+        // given
+        Point holdingPoint = Point.register(1000L,500L,10L, PointEnum.HOLDING,member,order);
+        when(pointRepository.findFirstByOrderAndStatusOrderByCreatedAtDesc(order,PointEnum.HOLDING))
+                .thenReturn(Optional.of(holdingPoint));
+
+        // when
+        pointService.completePoint(order);
+
+        // then
+        assertEquals(PointEnum.SAVE, holdingPoint.getStatus()); // 상태가 save로 변경
+        assertEquals(1500L, member.getTotalPoint());
+    }
+}


### PR DESCRIPTION
## 📌 PR 제목
feat: 포인트 구현 및 포인트 테스트코드 추가

---

## ✨ 변경 사항
- 포인트 서비스 구현
- 포인트 레포지토리 구현
- 포인트 엔티티 구현
- 포인트 테스트코드 작성
- 주문 엔티티 및 서비스 point -> totalPoint 로 변수명 변경
- 주문 엔티티에 @builder, @AllArgsConstructor 어노테이션 추가
- ErrorCode 추가

---

## 🔗 관련 이슈
- close #36 

---

## 🧪 테스트
어떤 테스트를 했는지 작성해주세요.

- [ ] API 테스트 완료
- [ ] Postman 테스트 완료
- [x] 예외 처리 확인
- [x] 테스트코드 확인

---

## 💡 참고 사항
- 포인트 테스트코드 진행을 위해 주문 엔티티에 @builder, @AllArgsConstructor 어노테이션 추가하였습니다.
- orderService 에는 아직 Point 로직 반영 전 입니다.