### PR TITLE
fix: 회원가입 시 role 값이 반영되도록 로직 수정

### DIFF
--- a/src/main/java/com/example/hungrypangproject/domain/member/dto/request/SaveMemberRequest.java
+++ b/src/main/java/com/example/hungrypangproject/domain/member/dto/request/SaveMemberRequest.java
@@ -1,5 +1,6 @@
 package com.example.hungrypangproject.domain.member.dto.request;
 
+import com.example.hungrypangproject.domain.member.entity.MemberRoleEnum;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,5 +16,6 @@ public class SaveMemberRequest {
     private String address;
     private String phoneNo;
     private String password;
+    private MemberRoleEnum role;
     private BigDecimal totalPoint;
 }

--- a/src/main/java/com/example/hungrypangproject/domain/member/entity/Member.java
+++ b/src/main/java/com/example/hungrypangproject/domain/member/entity/Member.java
@@ -58,7 +58,7 @@ public class Member extends BaseEntity {
         member.phoneNo = request.getPhoneNo();
         member.password = encodedPassword;
         member.totalPoint = BigDecimal.ZERO;
-        member.role = MemberRoleEnum.ROLE_USER;
+        member.role = request.getRole() != null ? request.getRole() : MemberRoleEnum.ROLE_USER;
         member.totalPriceAmount = BigDecimal.ZERO;
         return member;
     }


### PR DESCRIPTION
## 📌 PR 제목
fix: 회원가입 시 role 값이 반영되도록 로직 수정

---

## ✨ 변경 사항
이번 PR에서는 회원가입 시 요청으로 전달된 role 값이 반영되지 않고
항상 ROLE_USER로 저장되던 문제를 수정했습니다.

- Member.register() 메서드에서 role이 ROLE_USER로 고정되던 로직 수정
- 회원가입 요청에서 role 값이 전달되면 해당 role을 사용하도록 변경
- role 값이 없을 경우 기본 권한 ROLE_USER를 사용하도록 처리

---

## 🔗 관련 이슈
- close #52 

---

## 🧪 테스트
어떤 테스트를 했는지 작성해주세요.

- [x] API 테스트 완료
- [x] Postman 테스트 완료
- [ ] 예외 처리 확인

---

## 💡 참고 사항
회원가입 요청에서 role 값이 전달되지 않는 경우를 대비하여
기본 권한을 ROLE_USER로 설정하도록 처리했습니다.