### PR TITLE
feat: 캐시 설정 추가 및 식당 목록 조회 Pageable 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,10 @@ dependencies {
 
     // PortOne
     implementation 'com.github.iamport:iamport-rest-client-java:0.2.23'
+
+    // Cache
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'com.github.ben-manes.caffeine:caffeine'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/hungrypangproject/HungryPangProjectApplication.java
+++ b/src/main/java/com/example/hungrypangproject/HungryPangProjectApplication.java
@@ -2,10 +2,12 @@ package com.example.hungrypangproject;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableCaching
 public class HungryPangProjectApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/example/hungrypangproject/domain/store/controller/StoreController.java
+++ b/src/main/java/com/example/hungrypangproject/domain/store/controller/StoreController.java
@@ -9,6 +9,8 @@ import com.example.hungrypangproject.domain.store.dto.response.StoreResponse;
 import com.example.hungrypangproject.domain.store.service.StoreService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -36,11 +38,11 @@ public class StoreController {
 
     // 식당 목록 조회 (검색 기능)
     @GetMapping
-    public ApiResponse<List<StoreResponse>> getStores(
-            @RequestParam(required = false) String keyword
+    public ApiResponse<Page<StoreResponse>> getStores(
+            @RequestParam(required = false) String keyword,
+            Pageable pageable
     ) {
-        // keyword가 있으면 검색, 없으면 전체 조회
-        return ApiResponse.ok(storeService.getStores(keyword));
+        return ApiResponse.ok(storeService.getStores(keyword, pageable));
     }
 
     // 식당 단건 조회

--- a/src/main/java/com/example/hungrypangproject/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/example/hungrypangproject/domain/store/repository/StoreRepository.java
@@ -1,11 +1,13 @@
 package com.example.hungrypangproject.domain.store.repository;
 
 import com.example.hungrypangproject.domain.store.entity.Store;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface StoreRepository extends JpaRepository<Store, Long> {
 
-    List<Store> findByStoreNameContaining(String keyword);
+    Page<Store> findByStoreNameContaining(String keyword, Pageable pageable);
 }

--- a/src/main/java/com/example/hungrypangproject/domain/store/service/StoreService.java
+++ b/src/main/java/com/example/hungrypangproject/domain/store/service/StoreService.java
@@ -11,6 +11,8 @@ import com.example.hungrypangproject.domain.store.entity.Store;
 import com.example.hungrypangproject.domain.store.exception.StoreException;
 import com.example.hungrypangproject.domain.store.repository.StoreRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -46,22 +48,16 @@ public class StoreService {
 
     // 식당 목록 조회 (검색 기능)
     @Transactional(readOnly = true)
-    public List<StoreResponse> getStores(String keyword) {
-        List<Store> stores;
+    public Page<StoreResponse> getStores(String keyword, Pageable pageable) {
+        Page<Store> stores;
 
-        // 검색어가 없으면 전체 조회
         if (keyword == null || keyword.isBlank()) {
-            stores = storeRepository.findAll();
-        }
-        // 검색어가 있으면 이름 기준 검색
-        else {
-            stores = storeRepository.findByStoreNameContaining(keyword);
+            stores = storeRepository.findAll(pageable);
+        } else {
+            stores = storeRepository.findByStoreNameContaining(keyword, pageable);
         }
 
-        // Entity → Response DTO 변환
-        return stores.stream()
-                .map(StoreResponse::from)
-                .toList();
+        return stores.map(StoreResponse::from);
     }
 
     // 식당 단건 조회

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,10 @@ spring:
       hibernate:
         format_sql: true
 
+  cache:
+    caffeine:
+      spec: maximumSize=100,expireAfterWrite=10s
+
 portone:
   api:
     key: ${PORTONE_API_KEY:test_key}

--- a/src/test/java/com/example/hungrypangproject/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/com/example/hungrypangproject/domain/store/service/StoreServiceTest.java
@@ -18,6 +18,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -107,16 +111,19 @@ public class StoreServiceTest {
     @DisplayName("식당 목록 조회 성공 - 검색어가 있으면 이름으로 검색")
     void getStores_Success_WithKeyword() {
         // given
-        when(storeRepository.findByStoreNameContaining("치킨"))
-                .thenReturn(List.of(store));
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<Store> storePage = new PageImpl<>(List.of(store), pageable, 1);
+
+        when(storeRepository.findByStoreNameContaining("치킨", pageable))
+                .thenReturn(storePage);
 
         // when
-        List<StoreResponse> result = storeService.getStores("치킨");
+        Page<StoreResponse> result = storeService.getStores("치킨", pageable);
 
         // then
-        assertEquals(1, result.size());
-        verify(storeRepository, times(1)).findByStoreNameContaining("치킨");
-        verify(storeRepository, never()).findAll();
+        assertEquals(1, result.getContent().size());
+        verify(storeRepository, times(1)).findByStoreNameContaining("치킨", pageable);
+        verify(storeRepository, never()).findAll(any(Pageable.class));
     }
 
     @Test


### PR DESCRIPTION
## 📌 PR 제목
feat: 캐시 설정 추가 및 식당 목록 조회 Pageable 적용

---

## ✨ 변경 사항
이번 PR에서 변경된 내용입니다.

- 캐시 기능 사용을 위한 의존성 추가
- application.yml 캐시 설정 추가
- @EnableCaching 설정 적용
- 식당 목록 조회 API에 Pageable 적용
- 식당 목록 조회 API 성능 테스트 진행

---

## 🔗 관련 이슈
- close #65 

---

## 🧪 테스트
어떤 테스트를 했는지 작성해주세요.

- [x] Postman을 이용한 조회 API 테스트
- [x] Pageable 적용 전후 응답 시간 비교
- [x] 식당 목록 조회 정상 동작 확인
- [x] 검색 조건(keyword) 조회 테스트

---

## 💡 참고 사항
조회 API 성능 테스트 과정에서 일부 요청의 응답 시간이 상대적으로 길게 측정되는 것을 확인하였다.

이에 따라 바로 캐시를 적용하기보다는 먼저 조회 방식 자체를 개선하기 위해
식당 목록 조회 API에 Pageable을 적용하였다.

Pageable 적용 후 동일한 방식으로 테스트한 결과
약 121ms → 77ms 정도로 응답 시간이 일부 감소하는 것을 확인하였다.

다음 단계에서는 조회 API에 캐시(Cache)를 적용하고
캐싱 적용 전후 성능을 비교하여 성능 개선 효과를 확인할 예정이다.