### PR TITLE
feat: 조회 API 캐싱 적용

### DIFF
--- a/src/main/java/com/example/hungrypangproject/domain/menu/service/MenuService.java
+++ b/src/main/java/com/example/hungrypangproject/domain/menu/service/MenuService.java
@@ -14,6 +14,9 @@ import com.example.hungrypangproject.domain.store.entity.Store;
 import com.example.hungrypangproject.domain.store.exception.StoreException;
 import com.example.hungrypangproject.domain.store.repository.StoreRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,14 +25,14 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Transactional
 public class MenuService {
 
     private final MenuRepository menuRepository;
     private final StoreRepository storeRepository;
 
     // 메뉴 등록
-    @Transactional
+    @CacheEvict(value = "menusByStore", key = "#storeId")
     public MenuResponse createMenu(Long storeId, MenuCreateRequest request) {
 
         // 식당 조회 (없으면 예외 발생)
@@ -57,6 +60,8 @@ public class MenuService {
     }
 
     // 메뉴 목록 조회(식당별)
+    @Cacheable(value = "menusByStore", key = "#storeId")
+    @Transactional(readOnly = true)
     public List<MenuResponse> getMenusByStore(Long storeId) {
 
         // 해당 식당이 존재하는지 검증
@@ -70,6 +75,8 @@ public class MenuService {
     }
 
     // 메뉴 상세 조회
+    @Cacheable(value = "menu", key = "#menuId")
+    @Transactional(readOnly = true)
     public MenuResponse getMenu(Long menuId) {
 
         // 메뉴 조회 (없으면 예외 발생)
@@ -80,7 +87,7 @@ public class MenuService {
     }
 
     // 메뉴 수정
-    @Transactional
+    @Caching(evict = {@CacheEvict(value = "menu", key = "#menuId"), @CacheEvict(value = "menusByStore", allEntries = true)})
     public MenuResponse updateMenu(Long menuId, MenuUpdateRequest request) {
 
         // 메뉴 조회
@@ -98,7 +105,7 @@ public class MenuService {
     }
 
     // 메뉴 상태 변경
-    @Transactional
+    @Caching(evict = {@CacheEvict(value = "menu", key = "#menuId"), @CacheEvict(value = "menusByStore", allEntries = true)})
     public MenuResponse updateMenuStatus(Long menuId, MenuStatusUpdateRequest request) {
 
         // 메뉴 조회
@@ -111,7 +118,7 @@ public class MenuService {
     }
 
     // 메뉴 삭제
-    @Transactional
+    @Caching(evict = {@CacheEvict(value = "menu", key = "#menuId"), @CacheEvict(value = "menusByStore", allEntries = true)})
     public void deleteMenu(Long menuId) {
 
         // 메뉴 조회

--- a/src/main/java/com/example/hungrypangproject/domain/review/service/ReviewService.java
+++ b/src/main/java/com/example/hungrypangproject/domain/review/service/ReviewService.java
@@ -17,6 +17,8 @@ import com.example.hungrypangproject.domain.review.repository.ReviewRepository;
 import com.example.hungrypangproject.domain.store.entity.Store;
 import com.example.hungrypangproject.domain.store.repository.StoreRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,6 +34,7 @@ public class ReviewService {
     private final StoreRepository storeRepository;
 
     // 리뷰 작성
+    @CacheEvict(value = "storeReviews", key = "#result.storeId")
     public ReviewResponse createReview(Long orderId, Long loginMemberId, ReviewCreateRequest request) {
 
         // 주문 조회
@@ -74,6 +77,7 @@ public class ReviewService {
     }
 
     // 리뷰 목록 조회(식당별)
+    @Cacheable(value = "storeReviews", key = "#storeId")
     @Transactional(readOnly = true)
     public List<ReviewResponse> getStoreReviews(Long storeId) {
 
@@ -92,6 +96,7 @@ public class ReviewService {
     }
 
     // 리뷰 수정
+    @CacheEvict(value = "storeReviews", key = "#review.store.id")
     public ReviewResponse updateReview(Long reviewId, Long loginMemberId, ReviewUpdateRequest request) {
 
         // 삭제되지 않은 리뷰 조회
@@ -108,6 +113,7 @@ public class ReviewService {
     }
 
     // 리뷰 상태 변경
+    @CacheEvict(value = "storeReviews", allEntries = true)
     public ReviewResponse updateReviewStatus(Long reviewId, ReviewStatusUpdateRequest request, Member loginMember) {
 
         // 관리자 권한 확인
@@ -126,6 +132,7 @@ public class ReviewService {
     }
 
     // 리뷰 삭제
+    @CacheEvict(value = "storeReviews", allEntries = true)
     public void deleteReview(Long reviewId, Long loginMemberId) {
 
         // 삭제되지 않은 리뷰 조회

--- a/src/main/java/com/example/hungrypangproject/domain/store/service/StoreService.java
+++ b/src/main/java/com/example/hungrypangproject/domain/store/service/StoreService.java
@@ -11,6 +11,9 @@ import com.example.hungrypangproject.domain.store.entity.Store;
 import com.example.hungrypangproject.domain.store.exception.StoreException;
 import com.example.hungrypangproject.domain.store.repository.StoreRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -26,6 +29,7 @@ public class StoreService {
     private final StoreRepository storeRepository;
 
     // 식당 등록
+    @CacheEvict(value = "stores", allEntries = true)
     public StoreResponse createStore(StoreCreateRequest request, Member member) {
 
         // 판매자 권한 검증
@@ -47,6 +51,7 @@ public class StoreService {
     }
 
     // 식당 목록 조회 (검색 기능)
+    @Cacheable(value = "stores", key = "#keyword + '-' + #pageable.pageNumber + '-' + #pageable.pageSize")
     @Transactional(readOnly = true)
     public Page<StoreResponse> getStores(String keyword, Pageable pageable) {
         Page<Store> stores;
@@ -61,6 +66,7 @@ public class StoreService {
     }
 
     // 식당 단건 조회
+    @Cacheable(value = "store", key = "#storeId")
     @Transactional(readOnly = true)
     public StoreResponse getStore(Long storeId) {
         Store store = findStoreById(storeId);
@@ -68,6 +74,7 @@ public class StoreService {
     }
 
     // 식당 정보 수정
+    @Caching(evict = {@CacheEvict(value = "stores", allEntries = true), @CacheEvict(value = "store", key = "#storeId")})
     public void updateStore(Long storeId, StoreUpdateRequest request, Member member) {
 
         // 판매자 권한 검증
@@ -88,6 +95,7 @@ public class StoreService {
     }
 
     // 식당 영업 상태 변경
+    @Caching(evict = {@CacheEvict(value = "stores", allEntries = true), @CacheEvict(value = "store", key = "#storeId")})
     public void updateStoreStatus(Long storeId, StoreStatusUpdateRequest request, Member member) {
 
         // 판매자 권한 검증
@@ -104,6 +112,7 @@ public class StoreService {
     }
 
     // 식당 삭제
+    @Caching(evict = {@CacheEvict(value = "stores", allEntries = true), @CacheEvict(value = "store", key = "#storeId")})
     public void deleteStore(Long storeId, Member member) {
 
         // 판매자 권한 검증


### PR DESCRIPTION
## 📌 PR 제목
feat: 조회 API 캐싱 적용

---

## ✨ 변경 사항
이번 PR에서 변경된 내용을 작성해주세요.

- Store 조회 API 캐싱 적용
- Menu 조회 API 캐싱 적용
- Review 조회 API 캐싱 적용
- 데이터 변경 API(create/update/delete)에 `@CacheEvict` 적용

---

## 🔗 관련 이슈
- close #71 

---

## 🧪 테스트
어떤 테스트를 했는지 작성해주세요.

- [x] API 테스트 완료
- [x] Postman 테스트 완료
- [x] 캐싱 적용 전후 응답 속도 비교 테스트 진행
- [x] 예외 처리 정상 동작 확인

---

## 💡 참고 사항
- 조회 API에는 `@Cacheable`을 적용하여 조회 결과를 캐싱하도록 구현했습니다.
- 데이터 변경이 발생하는 API(create/update/delete)에는 `@CacheEvict`를 적용하여 캐시가 갱신되도록 처리했습니다.
- 캐싱 적용 후 Postman을 통해 응답 속도 비교 테스트를 진행했습니다.