### PR TITLE
refactor: 포인트 동시성 테스트코드 수정 및 주석 처리 정리

### DIFF
--- a/src/main/java/com/example/hungrypangproject/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/hungrypangproject/common/exception/ErrorCode.java
@@ -3,7 +3,6 @@ package com.example.hungrypangproject.common.exception;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import retrofit2.http.HTTP;
 
 @Getter
 @RequiredArgsConstructor
@@ -42,6 +41,7 @@ public enum ErrorCode {
     POINT_NOT_ENOUGH(HttpStatus.BAD_REQUEST, "포인트가 부족합니다."),
     POINT_EXCEED_LIMIT(HttpStatus.BAD_REQUEST, "포인트는 결제금액의 10% 이하만 사용 가능합니다."),
     POINT_NOT_HOLDING(HttpStatus.BAD_REQUEST, "적립 대기중인 포인트가 없습니다."),
+    ALREADY_POINT_USED(HttpStatus.BAD_REQUEST,"이미 포인트 결제가 처리된 주문입니다."),
 
     //MEMBER
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저를 찾을수 없습니다."),

--- a/src/main/java/com/example/hungrypangproject/common/security/JwtUtil.java
+++ b/src/main/java/com/example/hungrypangproject/common/security/JwtUtil.java
@@ -17,15 +17,9 @@ import java.util.Date;
 @Component
 public class JwtUtil {
 
-     //기본 셋팅
-//    public static final String BEARER_PREFIX = "Bearer ";
-//    private static final long ACCESS_TOKEN_TIME = 60 * 60 * 1000L; // token 발급 시간 60분
-//    private static final long REFRESH_TOKEN_TIME = 14 * 24 * 60 * 60 * 1000L; // Refresh token 발급 2주
-
-    // 테스트용
     public static final String BEARER_PREFIX = "Bearer ";
-    private static final long ACCESS_TOKEN_TIME = 60 * 1000L; // token 발급 시간 5분
-    private static final long REFRESH_TOKEN_TIME = 2 * 60 * 1000L; // Refresh token 발급 6분
+    private static final long ACCESS_TOKEN_TIME = 60 * 60 * 1000L; // token 발급 시간 60분
+    private static final long REFRESH_TOKEN_TIME = 14 * 24 * 60 * 60 * 1000L; // Refresh token 발급 2주
 
     private SecretKey secretKey;
     private JwtParser jwtparser;
@@ -33,7 +27,6 @@ public class JwtUtil {
     @Value("${jwt.secret.key}")
     private String secretKeyString;
 
-    // jwt 라이브러리에서 필요한 내용들 셋팅
     @PostConstruct
     public void init() {
         byte[] bytes = Decoders.BASE64.decode(secretKeyString);
@@ -43,7 +36,6 @@ public class JwtUtil {
                 .build();
     }
 
-    // Access token 생성
     public String createAccessToken(String email, MemberRoleEnum role) {
         Date now = new Date();
         return BEARER_PREFIX + Jwts.builder()
@@ -56,7 +48,6 @@ public class JwtUtil {
                 .compact();
     }
 
-    // Refresh Token 생성 (수명 연장)
     public String createRefreshToken(String email) {
         Date now = new Date();
         return BEARER_PREFIX + Jwts.builder()
@@ -76,7 +67,6 @@ public class JwtUtil {
         throw new NullPointerException("토큰이 없거나 유효하지 않습니다.");
     }
 
-    // substringToken 으로 가공된 토큰을 받아 검증
     public boolean validateToken(String token) {
         if (token == null || token.isBlank()) return false;
         try {
@@ -110,7 +100,6 @@ public class JwtUtil {
         }
     }
 
-    // 토큰에 있는 내용 꺼내기 (정보 추출용)
     private Claims getClaims (String token) {
         return jwtparser.parseSignedClaims(token).getPayload();
     }

--- a/src/main/java/com/example/hungrypangproject/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/hungrypangproject/domain/member/controller/MemberController.java
@@ -2,7 +2,6 @@ package com.example.hungrypangproject.domain.member.controller;
 
 import com.example.hungrypangproject.domain.member.dto.request.*;
 import com.example.hungrypangproject.domain.member.dto.respons.*;
-import com.example.hungrypangproject.domain.member.entity.Member;
 import com.example.hungrypangproject.domain.member.entity.MemberUserDetails;
 import com.example.hungrypangproject.domain.member.service.MemberService;
 import jakarta.validation.Valid;

--- a/src/main/java/com/example/hungrypangproject/domain/member/entity/Member.java
+++ b/src/main/java/com/example/hungrypangproject/domain/member/entity/Member.java
@@ -21,9 +21,6 @@ public class Member extends BaseEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long memberId;
 
-    @Version
-    private Long version;
-
     @Column(nullable = false, length = 20)
     private String nickname;
 

--- a/src/main/java/com/example/hungrypangproject/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/hungrypangproject/domain/member/repository/MemberRepository.java
@@ -2,27 +2,23 @@ package com.example.hungrypangproject.domain.member.repository;
 
 import com.example.hungrypangproject.domain.member.entity.Member;
 import com.example.hungrypangproject.domain.member.entity.MemberRoleEnum;
-import com.example.hungrypangproject.domain.point.entity.Point;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    // 이메일 중복 체크
+
     boolean existsByEmail(String email);
     Optional<Member> findByEmail(String email);
-
     List<Member> findAllByRole(MemberRoleEnum role);
 
-    // totalPoint 차감 및 적립에 대한 비관적 락
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("SELECT m FROM Member m WHERE m.totalPoint = :totalPoint")
-    Optional<Member> findByaTotalPointForLock(@Param("totalPoint") BigDecimal totalPoint);
+    @Query("SELECT m FROM Member m WHERE m.memberId = :memberId")
+    Optional<Member> findByaMemberIdForLock(@Param("memberId") Long memberId);
 
 }

--- a/src/main/java/com/example/hungrypangproject/domain/point/entity/Point.java
+++ b/src/main/java/com/example/hungrypangproject/domain/point/entity/Point.java
@@ -1,13 +1,10 @@
 package com.example.hungrypangproject.domain.point.entity;
 
 import com.example.hungrypangproject.common.entity.BaseEntity;
-import com.example.hungrypangproject.common.exception.ErrorCode;
-import com.example.hungrypangproject.common.exception.ServiceException;
 import com.example.hungrypangproject.domain.member.entity.Member;
 import com.example.hungrypangproject.domain.order.entity.Order;
 import jakarta.persistence.*;
 import lombok.*;
-import org.aspectj.weaver.ast.Or;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -26,15 +23,12 @@ public class Point extends BaseEntity {
     @Version
     private Long version;
 
-    // 현재 총 포인트
     @Column(nullable = false)
     private BigDecimal currentlyPoint;
 
-    // 적립 포인트
     @Column(nullable = false)
     private BigDecimal earnPoint;
 
-    // 사용 포인트
     @Column(nullable = false)
     private BigDecimal usedPoint;
 

--- a/src/main/java/com/example/hungrypangproject/domain/point/entity/PointEnum.java
+++ b/src/main/java/com/example/hungrypangproject/domain/point/entity/PointEnum.java
@@ -1,7 +1,6 @@
 package com.example.hungrypangproject.domain.point.entity;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
 public enum PointEnum {

--- a/src/main/java/com/example/hungrypangproject/domain/point/repository/PointRepository.java
+++ b/src/main/java/com/example/hungrypangproject/domain/point/repository/PointRepository.java
@@ -9,4 +9,5 @@ import java.util.Optional;
 
 public interface PointRepository extends JpaRepository <Point, Long> {
     Optional<Point> findFirstByOrderAndStatusOrderByCreatedAtDesc(Order order, PointEnum status);
+    Boolean existsByOrderAndStatus (Order order, PointEnum status);
 }

--- a/src/main/java/com/example/hungrypangproject/domain/point/service/PointService.java
+++ b/src/main/java/com/example/hungrypangproject/domain/point/service/PointService.java
@@ -29,16 +29,8 @@ public class PointService {
      * 주문 서비스와 동시에 롤백이 되지 않게 Transactional 삭제
      */
 
-      private final PointRepository pointRepository;
+    private final PointRepository pointRepository;
     private final MemberRepository memberRepository;
-//
-//    @Transactional
-//    public void withdraw(Long memberId, int amount) {
-//        Point point = pointRepository.findById(memberId).orElseThrow();
-//
-//        point.decrease(amount);
-//        log.info("[사용 완료] {} 에서 실행 되었습니다. 잔여 포인트 : " + Thread.currentThread().getName(), point.getCurrentlyPoint());
-//    }
 
     public BigDecimal calculateEarnedPoints (BigDecimal totalPrice, BigDecimal usedPoints) {
         BigDecimal payAmount = totalPrice.subtract(usedPoints);
@@ -48,9 +40,16 @@ public class PointService {
 
     @Transactional
     public void usedPoint(Member member, Order order, BigDecimal useAmount) {
+
         // 락 걸고 회원 정보 다시 가져오기
-        Member lockdMember = memberRepository.findByaTotalPointForLock(member.getTotalPoint())
+        Member lockdMember = memberRepository.findByaMemberIdForLock(member.getMemberId())
                 .orElseThrow(() -> new ServiceException(ErrorCode.MEMBER_NOT_FOUND));
+
+        // 주문으로 포인트 차감 로그 존재 확인
+        boolean alreadyPointUsed = pointRepository.existsByOrderAndStatus(order, PointEnum.HOLDING);
+        if (alreadyPointUsed) {
+            throw new ServiceException(ErrorCode.ALREADY_POINT_USED);
+        }
 
         if(useAmount.compareTo(new BigDecimal("100")) < 0) {
             throw new ServiceException(ErrorCode.POINT_NOT_ENOUGH);
@@ -81,6 +80,7 @@ public class PointService {
    }
 
     public void reserveEarnPoint(Member member, Order order, BigDecimal earnAmount) {
+
         // 배달 완료 전 홀딩 상태 포인트 확인
         Point earnLog = Point.register(
                 member.getTotalPoint(),
@@ -94,7 +94,8 @@ public class PointService {
    }
 
     public void completePoint(Order order) {
-       // 적립 홀딩 상태 확인
+
+        // 적립 홀딩 상태 확인
        Point point = pointRepository.findFirstByOrderAndStatusOrderByCreatedAtDesc(order, PointEnum.HOLDING)
                .orElseThrow(() -> new ServiceException(ErrorCode.POINT_NOT_HOLDING));
 

--- a/src/main/java/com/example/hungrypangproject/domain/store/entity/Store.java
+++ b/src/main/java/com/example/hungrypangproject/domain/store/entity/Store.java
@@ -3,9 +3,7 @@ package com.example.hungrypangproject.domain.store.entity;
 import com.example.hungrypangproject.common.entity.BaseEntity;
 import com.example.hungrypangproject.domain.member.entity.Member;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.math.BigDecimal;
 
@@ -13,6 +11,8 @@ import java.math.BigDecimal;
 @Entity
 @Table(name = "stores")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class Store extends BaseEntity {
 
     @Id

--- a/src/test/java/com/example/hungrypangproject/common/security/JwtUtilTest.java
+++ b/src/test/java/com/example/hungrypangproject/common/security/JwtUtilTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.*;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.util.ReflectionTestUtils;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Base64;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -21,6 +20,7 @@ class JwtUtilTest {
     @BeforeEach
     void setUp() {
         jwtUtil = new JwtUtil();
+
         // @Value로 들어가는 값을 수동으로 설정 (Reflection 사용)
         String encodedKey = Base64.getEncoder().encodeToString(secretKey.getBytes());
         ReflectionTestUtils.setField(jwtUtil, "secretKeyString", encodedKey);
@@ -38,7 +38,7 @@ class JwtUtilTest {
 
         // when
         String token = jwtUtil.createAccessToken(email, role);
-        String pureToken = jwtUtil.substringToken(token); // Bearer 제거
+        String pureToken = jwtUtil.substringToken(token);
         String extractedEmail = jwtUtil.extractEmail(pureToken);
 
         // then

--- a/src/test/java/com/example/hungrypangproject/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/example/hungrypangproject/domain/member/service/MemberServiceTest.java
@@ -57,12 +57,11 @@ class MemberServiceTest {
     @InjectMocks
     private MemberService memberService;
 
-    // 회원가입 테스트 (성공 케이스)
     @Test
     @DisplayName("회원가입 성공")
     void signup_Success() {
-        // given
 
+        // given
         SaveMemberRequest request = new SaveMemberRequest(
                 "테스트",
                 "test@test.com",
@@ -83,7 +82,6 @@ class MemberServiceTest {
         verify(memberRepository, times(1)).save(any(Member.class));
     }
 
-    // 회원가입 테스트 (이미 존재하는 이메일 실패 케이스)
     @Test
     @DisplayName("중복 이메일 회원가입 시 예외 발생")
     void signup_Fail_DuplicateEmail() {
@@ -104,7 +102,6 @@ class MemberServiceTest {
                 .hasMessageContaining(ErrorCode.EMAIL_ALREADY_EXISTS.getMessage());
     }
 
-    // 로그인 테스트 (AuthenticationManager 가짜 인증 처리)
     @Test
     @DisplayName("로그인 성공")
     void login_Success() {
@@ -131,7 +128,6 @@ class MemberServiceTest {
         assertThat(result.getRefreshToken()).isEqualTo("refresh_token");
     }
 
-    //  리프레시 토큰 테스트
     @Test
     @DisplayName("Redis 리프레시 토큰 재발급 성공")
     void refresh_Success() {

--- a/src/test/java/com/example/hungrypangproject/domain/point/service/PointServiceConcurrencyTest.java
+++ b/src/test/java/com/example/hungrypangproject/domain/point/service/PointServiceConcurrencyTest.java
@@ -6,6 +6,9 @@ import com.example.hungrypangproject.domain.member.repository.MemberRepository;
 import com.example.hungrypangproject.domain.order.entity.Order;
 import com.example.hungrypangproject.domain.order.entity.OrderStatus;
 import com.example.hungrypangproject.domain.order.repository.OrderRepository;
+import com.example.hungrypangproject.domain.store.entity.Store;
+import com.example.hungrypangproject.domain.store.entity.StoreStatus;
+import com.example.hungrypangproject.domain.store.repository.StoreRepository;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -13,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -30,6 +34,9 @@ public class PointServiceConcurrencyTest {
     @Autowired
     private OrderRepository orderRepository;
 
+    @Autowired
+    private StoreRepository storeRepository;
+
     @Test
     @DisplayName("포인트 사용 시 동시에 10개의 요청이 와도 1번만 차감되어야 한다")
     void concurrencyTest() throws InterruptedException {
@@ -43,10 +50,22 @@ public class PointServiceConcurrencyTest {
                 .totalPriceAmount(new BigDecimal("100000"))
                 .totalPoint(new BigDecimal("10000"))
                 .build());
+
+        Store store = storeRepository.save(Store.builder()
+                .storeName("배고팡")
+                .status(StoreStatus.OPEN)
+                .seller(member)
+                .build());
+
         Order order = orderRepository.save(Order.builder()
                 .totalPrice(new BigDecimal("50000"))
-                .id(member.getMemberId())
+                .member(member)
+                .orderAt(LocalDateTime.now())
+                .orderNum(UUID.randomUUID())
+                .orderStatus(OrderStatus.WAITING)
+                .store(store)
                 .build());
+
         BigDecimal useAmount = new BigDecimal("1000");
 
         // 동시 요청 수
@@ -70,7 +89,7 @@ public class PointServiceConcurrencyTest {
                     latch.countDown();
                 }
             });
-
+        }
             // 모든 스레드가 종료될 때까지 대기
             latch.await();
 
@@ -81,4 +100,3 @@ public class PointServiceConcurrencyTest {
                     .isEqualByComparingTo(new BigDecimal("9000"));
         }
     }
-}


### PR DESCRIPTION
## 📌 PR 제목
refactor: 포인트 동시성 테스트코드 수정 및 주석 처리 정리

---

## ✨ 변경 사항
- ErrorCode : "이미 사용된 포인트입니다." 추가
- MemberEntity : 낙관적 락 삭제
- MemberRepotitory : totalPoint -> MemberId 로 비관적 락 대상 변경
- PointRepository 및 PointService : 따닥 이슈로 인한 포인트 사용 에러 검수 로직 추가
- Store : 테스트코드 사용을 위한 @Builder, @AllArgsConstructor 추가
- 그 외 : 불필요한 주석 정리

---

## 🔗 관련 이슈
#78 

---

## 🧪 테스트
어떤 테스트를 했는지 작성해주세요.

- [ ] API 테스트 완료
- [ ] Postman 테스트 완료
- [ ] 예외 처리 확인
- [x] 유닛, 전체 테스트코드 

---

## 💡 참고 사항
MemberRepotitory : totalPoint 로 테스트코드 진행 중, 무한 대기 버그로 인해 MemberId 로 변경