### PR TITLE
feat: 식당 totalReviewCount 컬럼 추가 및 리뷰 동시성 처리

### DIFF
--- a/src/main/java/com/example/hungrypangproject/domain/review/service/ReviewService.java
+++ b/src/main/java/com/example/hungrypangproject/domain/review/service/ReviewService.java
@@ -46,7 +46,11 @@ public class ReviewService {
                 .orElseThrow(() -> new ReviewException(ErrorCode.ORDER_NOT_FOUND));
 
         Member member = order.getMember();
-        Store store = order.getStore();
+        Long storeId = order.getStore().getId();
+
+        // 비관적 락으로 식당 조회
+        Store store = storeRepository.findByIdWithPessimisticLock(storeId)
+                .orElseThrow(() -> new ReviewException(ErrorCode.STORE_NOT_FOUND));
 
         // 본인 주문인지 확인
         if (!member.getMemberId().equals(loginMemberId)) {
@@ -75,6 +79,9 @@ public class ReviewService {
 
         // 리뷰 저장
         Review savedReview = reviewRepository.save(review);
+
+        // 식당 총 리뷰 수 증가
+        store.increaseReviewCount();
 
         // DTO 변환 후 반환
         return ReviewResponse.from(savedReview);
@@ -139,15 +146,25 @@ public class ReviewService {
     @CacheEvict(value = "storeReviews", allEntries = true)
     public void deleteReview(Long reviewId, Long loginMemberId) {
 
-        // 삭제되지 않은 리뷰 조회
+        // 삭제되지 않은 리뷰 조회 (DELETED 상태 제외)
         Review review = reviewRepository.findByIdAndStatusNot(reviewId, ReviewStatus.DELETED)
-                .orElseThrow(() -> new IllegalArgumentException("리뷰를 찾을 수 없습니다."));
+                .orElseThrow(() -> new ReviewException(ErrorCode.REVIEW_NOT_FOUND));
 
-        // 본인 리뷰인지 검증
+        // 본인 리뷰인지 검증 (작성자만 삭제 가능)
         validateReviewOwner(review, loginMemberId);
 
-        // soft delete 처리
+        // 리뷰가 속한 식당 ID 조회
+        Long storeId = review.getStore().getId();
+
+        // 동시성 문제 방지를 위해 비관적 락으로 식당 조회
+        // → 여러 트랜잭션이 동시에 리뷰 수를 수정하지 못하도록 row lock
+        Store store = storeRepository.findByIdWithPessimisticLock(storeId)
+                .orElseThrow(() -> new ReviewException(ErrorCode.STORE_NOT_FOUND));
+
+        // 리뷰 soft delete 처리 (상태를 DELETED로 변경)
         review.delete();
+        // 식당 총 리뷰 수 감소 (리뷰 삭제에 따른 집계 값 반영)
+        store.decreaseReviewCount();
     }
 
     // 리뷰 좋아요 등록

--- a/src/main/java/com/example/hungrypangproject/domain/store/dto/response/StoreResponse.java
+++ b/src/main/java/com/example/hungrypangproject/domain/store/dto/response/StoreResponse.java
@@ -19,6 +19,7 @@ public class StoreResponse implements Serializable {
     private BigDecimal deliveryFee;
     private StoreStatus status;
     private BigDecimal minimumOrder;
+    private Long totalReviewCount;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
 
@@ -29,6 +30,7 @@ public class StoreResponse implements Serializable {
                 .deliveryFee(store.getDeliveryFee())
                 .status(store.getStatus())
                 .minimumOrder(store.getMinimumOrder())
+                .totalReviewCount(store.getTotalReviewCount())
                 .createdAt(store.getCreatedAt())
                 .modifiedAt(store.getModifiedAt())
                 .build();

--- a/src/main/java/com/example/hungrypangproject/domain/store/entity/Store.java
+++ b/src/main/java/com/example/hungrypangproject/domain/store/entity/Store.java
@@ -19,6 +19,10 @@ public class Store extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false, name = "member_id")
+    private Member seller;
+
     @Column(name = "store_name", nullable = false, length = 10)
     private String storeName;
 
@@ -32,9 +36,8 @@ public class Store extends BaseEntity {
     @Column(name = "minimum_order")
     private BigDecimal minimumOrder;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(nullable = false, name = "member_id")
-    private Member seller;
+    @Column(name = "total_review_count", nullable = false)
+    private Long totalReviewCount;
 
     public static Store create(
             String storeName,
@@ -48,6 +51,7 @@ public class Store extends BaseEntity {
         store.status = StoreStatus.OPEN;
         store.minimumOrder = minimumOrder;
         store.seller = seller;
+        store.totalReviewCount = 0L;
         return store;
     }
 
@@ -64,4 +68,8 @@ public class Store extends BaseEntity {
     public boolean isOwner(Long memberId) {
         return this.seller.getMemberId().equals(memberId);
     }
+
+    public void increaseReviewCount() { this.totalReviewCount++; }
+
+    public void decreaseReviewCount() { if (this.totalReviewCount > 0) { this.totalReviewCount--; }}
 }

--- a/src/main/java/com/example/hungrypangproject/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/example/hungrypangproject/domain/store/repository/StoreRepository.java
@@ -1,13 +1,22 @@
 package com.example.hungrypangproject.domain.store.repository;
 
 import com.example.hungrypangproject.domain.store.entity.Store;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface StoreRepository extends JpaRepository<Store, Long> {
 
     Page<Store> findByStoreNameContaining(String keyword, Pageable pageable);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select s from Store s where s.id = :storeId")
+    Optional<Store> findByIdWithPessimisticLock(@Param("storeId") Long storeId);
 }

--- a/src/test/java/com/example/hungrypangproject/domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/example/hungrypangproject/domain/review/service/ReviewServiceTest.java
@@ -23,6 +23,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
@@ -32,6 +34,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
+import static org.testcontainers.shaded.org.bouncycastle.asn1.x500.style.RFC4519Style.member;
 
 @ExtendWith(MockitoExtension.class)
 public class ReviewServiceTest {
@@ -44,6 +47,12 @@ public class ReviewServiceTest {
 
     @Mock
     private StoreRepository storeRepository;
+
+    @Mock
+    private StringRedisTemplate stringRedisTemplate;
+
+    @Mock
+    private HashOperations<String, Object, Object> hashOperations;
 
     @InjectMocks
     private ReviewService reviewService;
@@ -80,6 +89,7 @@ public class ReviewServiceTest {
         when(order.getOrderStatus()).thenReturn(OrderStatus.COMPLETED);
 
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
+        when(storeRepository.findByIdWithPessimisticLock(1L)).thenReturn(Optional.of(store));
         when(reviewRepository.existsByOrderId(1L)).thenReturn(false);
 
         when(reviewRepository.save(any(Review.class))).thenAnswer(invocation -> {
@@ -101,8 +111,10 @@ public class ReviewServiceTest {
         assertEquals("정말 맛있어요!", response.getContent());
 
         verify(orderRepository, times(1)).findById(1L);
+        verify(storeRepository, times(1)).findByIdWithPessimisticLock(1L);
         verify(reviewRepository, times(1)).existsByOrderId(1L);
         verify(reviewRepository, times(1)).save(any(Review.class));
+        verify(store, times(1)).increaseReviewCount();
     }
 
     @Test
@@ -123,8 +135,10 @@ public class ReviewServiceTest {
         assertEquals(ErrorCode.ORDER_NOT_FOUND.getMessage(), exception.getMessage());
 
         verify(orderRepository, times(1)).findById(1L);
+        verify(storeRepository, never()).findByIdWithPessimisticLock(anyLong());
         verify(reviewRepository, never()).existsByOrderId(anyLong());
         verify(reviewRepository, never()).save(any(Review.class));
+        verify(store, never()).increaseReviewCount();
     }
 
     @Test
@@ -136,9 +150,14 @@ public class ReviewServiceTest {
         ReflectionTestUtils.setField(request, "content", "정말 맛있어요!");
 
         when(member.getMemberId()).thenReturn(1L);
+        when(store.getId()).thenReturn(1L);
+
         when(order.getMember()).thenReturn(member);
+        when(order.getStore()).thenReturn(store);
         when(order.getOrderStatus()).thenReturn(OrderStatus.PREPARING);
+
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
+        when(storeRepository.findByIdWithPessimisticLock(1L)).thenReturn(Optional.of(store));
 
         // when
         ReviewException exception = assertThrows(ReviewException.class,
@@ -148,8 +167,10 @@ public class ReviewServiceTest {
         assertEquals(ErrorCode.REVIEW_ORDER_NOT_COMPLETED.getMessage(), exception.getMessage());
 
         verify(orderRepository, times(1)).findById(1L);
+        verify(storeRepository, times(1)).findByIdWithPessimisticLock(1L);
         verify(reviewRepository, never()).existsByOrderId(anyLong());
         verify(reviewRepository, never()).save(any(Review.class));
+        verify(store, never()).increaseReviewCount();
     }
 
     @Test
@@ -161,9 +182,12 @@ public class ReviewServiceTest {
         ReflectionTestUtils.setField(request, "content", "정말 맛있어요!");
 
         when(member.getMemberId()).thenReturn(2L);
+        when(store.getId()).thenReturn(1L);
+
         when(order.getMember()).thenReturn(member);
         when(order.getStore()).thenReturn(store);
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
+        when(storeRepository.findByIdWithPessimisticLock(1L)).thenReturn(Optional.of(store));
 
         // when
         ReviewException exception = assertThrows(ReviewException.class,
@@ -173,8 +197,10 @@ public class ReviewServiceTest {
         assertEquals(ErrorCode.REVIEW_ORDER_FORBIDDEN.getMessage(), exception.getMessage());
 
         verify(orderRepository, times(1)).findById(1L);
+        verify(storeRepository, times(1)).findByIdWithPessimisticLock(1L);
         verify(reviewRepository, never()).existsByOrderId(anyLong());
         verify(reviewRepository, never()).save(any(Review.class));
+        verify(store, never()).increaseReviewCount();
     }
 
     @Test
@@ -186,11 +212,14 @@ public class ReviewServiceTest {
         ReflectionTestUtils.setField(request, "content", "정말 맛있어요!");
 
         when(member.getMemberId()).thenReturn(1L);
+        when(store.getId()).thenReturn(1L);
 
         when(order.getMember()).thenReturn(member);
+        when(order.getStore()).thenReturn(store);
         when(order.getOrderStatus()).thenReturn(OrderStatus.COMPLETED);
 
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
+        when(storeRepository.findByIdWithPessimisticLock(1L)).thenReturn(Optional.of(store));
         when(reviewRepository.existsByOrderId(1L)).thenReturn(true);
 
         // when
@@ -201,8 +230,10 @@ public class ReviewServiceTest {
         assertEquals(ErrorCode.REVIEW_ALREADY_EXISTS.getMessage(), exception.getMessage());
 
         verify(orderRepository, times(1)).findById(1L);
+        verify(storeRepository, times(1)).findByIdWithPessimisticLock(1L);
         verify(reviewRepository, times(1)).existsByOrderId(1L);
         verify(reviewRepository, never()).save(any(Review.class));
+        verify(store, never()).increaseReviewCount();
     }
 
     @Test
@@ -382,12 +413,18 @@ public class ReviewServiceTest {
         when(review.getMember()).thenReturn(member);
         when(member.getMemberId()).thenReturn(1L);
 
+        when(review.getStore()).thenReturn(store);
+        when(store.getId()).thenReturn(1L);
+        when(storeRepository.findByIdWithPessimisticLock(1L)).thenReturn(Optional.of(store));
+
         // when
         reviewService.deleteReview(1L, 1L);
 
         // then
         verify(reviewRepository, times(1)).findByIdAndStatusNot(1L, ReviewStatus.DELETED);
+        verify(storeRepository, times(1)).findByIdWithPessimisticLock(1L);
         verify(review, times(1)).delete();
+        verify(store, times(1)).decreaseReviewCount();
     }
 
     @Test
@@ -398,14 +435,14 @@ public class ReviewServiceTest {
                 .thenReturn(Optional.empty());
 
         // when
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+        ReviewException exception = assertThrows(ReviewException.class,
                 () -> reviewService.deleteReview(1L, 1L));
 
         // then
-        assertEquals("리뷰를 찾을 수 없습니다.", exception.getMessage());
+        assertEquals(ErrorCode.REVIEW_NOT_FOUND.getMessage(), exception.getMessage());
 
         verify(reviewRepository, times(1)).findByIdAndStatusNot(1L, ReviewStatus.DELETED);
-        verify(reviewRepository, never()).save(any());
+        verify(storeRepository, never()).findByIdWithPessimisticLock(anyLong());
     }
 
     @Test
@@ -428,6 +465,7 @@ public class ReviewServiceTest {
         assertEquals(ErrorCode.REVIEW_FORBIDDEN.getMessage(), exception.getMessage());
 
         verify(reviewRepository, times(1)).findByIdAndStatusNot(1L, ReviewStatus.DELETED);
+        verify(storeRepository, never()).findByIdWithPessimisticLock(anyLong());
         verify(review, never()).delete();
     }
 
@@ -439,13 +477,19 @@ public class ReviewServiceTest {
 
         when(reviewRepository.findById(1L))
                 .thenReturn(Optional.of(review));
+        when(stringRedisTemplate.opsForHash())
+                .thenReturn(hashOperations);
+        when(hashOperations.increment("review:like:delta", "1", 1))
+                .thenReturn(1L);
 
         // when
         reviewService.likeReview(1L);
 
         // then
         verify(reviewRepository, times(1)).findById(1L);
-        verify(review, times(1)).increaseLikeCount(1L);
+        verify(stringRedisTemplate, times(1)).opsForHash();
+        verify(hashOperations, times(1))
+                .increment("review:like:delta", "1", 1);
     }
 
     @Test
@@ -462,7 +506,7 @@ public class ReviewServiceTest {
         // then
         assertEquals(ErrorCode.REVIEW_NOT_FOUND.getMessage(), exception.getMessage());
         verify(reviewRepository, times(1)).findById(1L);
-        verify(reviewRepository, never()).findByIdAndStatusNot(anyLong(), any());
+        verify(stringRedisTemplate, never()).opsForHash();
     }
 
     @Test
@@ -473,13 +517,19 @@ public class ReviewServiceTest {
 
         when(reviewRepository.findById(1L))
                 .thenReturn(Optional.of(review));
+        when(stringRedisTemplate.opsForHash())
+                .thenReturn(hashOperations);
+        when(hashOperations.increment("review:like:delta", "1", -1))
+                .thenReturn(0L);
 
         // when
         reviewService.unlikeReview(1L);
 
         // then
         verify(reviewRepository, times(1)).findById(1L);
-        verify(review, times(1)).decreaseLikeCount(1L);
+        verify(stringRedisTemplate, times(1)).opsForHash();
+        verify(hashOperations, times(1))
+                .increment("review:like:delta", "1", -1);
     }
 
     @Test
@@ -496,6 +546,6 @@ public class ReviewServiceTest {
         // then
         assertEquals(ErrorCode.REVIEW_NOT_FOUND.getMessage(), exception.getMessage());
         verify(reviewRepository, times(1)).findById(1L);
-        verify(reviewRepository, never()).findByIdAndStatusNot(anyLong(), any());
+        verify(stringRedisTemplate, never()).opsForHash();
     }
 }


### PR DESCRIPTION
## 📌 PR 제목
feat: 식당 totalReviewCount 컬럼 추가 및 리뷰 동시성 처리

---

## ✨ 변경 사항
이번 PR에서 변경된 내용을 작성해주세요.

- store 테이블에 totalReviewCount 컬럼 추가 (NOT NULL, DEFAULT 0)
- Store 엔티티에 totalReviewCount 필드 추가 및 초기값 설정
- 리뷰 생성 시 totalReviewCount 증가 로직 추가
- 식당 조회 시 비관적 락 적용 (동시성 처리)
- ReviewService 로직 수정
- StoreResponse 등 응답 DTO 수정
- 테스트 코드 수정 및 검증

---

## 🔗 관련 이슈
- close #87 

---

## 🧪 테스트
어떤 테스트를 했는지 작성해주세요.

- [x] 리뷰 생성 시 totalReviewCount 정상 증가 확인
- [x] 동시 요청 시 데이터 정합성 유지 확인
- [x] 기존 리뷰 조회 기능 정상 동작 확인
- [x] 예외 상황 테스트 (존재하지 않는 주문/식당 등)

---

## 💡 참고 사항
- 조회 성능 개선을 위해 집계 컬럼(totalReviewCount)을 도입하였습니다.
- 리뷰 생성 시 해당 값을 함께 관리하도록 구조를 변경했습니다.
- 동시성 문제를 해결하기 위해 비관적 락을 적용했습니다.
- 현재는 데이터 정합성을 우선으로 고려한 설계이며, 추후 트래픽 증가 시 Redis 캐싱 또는 비동기 처리로 확장 가능하도록 고려했습니다.